### PR TITLE
ARC-416: Breadcrumbs Function

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -20,6 +20,7 @@
     gap: var(--magentaa11y-spacing-size-40);
     flex-grow: 1;
     padding: var(--main-content-padding);
+    overflow: auto;
   }
 
   @media (max-width: 768px) {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,13 +1,29 @@
 @use "@material/web/menu/_menu.scss" as *;
 
 .MagentaA11y {
+  --main-content-padding: var(--magentaa11y-spacing-size-24)
+    var(--magentaa11y-spacing-size-32);
+
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-}
 
-.MagentaA11y__content {
-  display: flex;
-  flex-direction: row;
-  flex-grow: 1;
+  &__content {
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+  }
+
+  &__main-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--magentaa11y-spacing-size-40);
+    flex-grow: 1;
+    padding: var(--main-content-padding);
+  }
+
+  @media (max-width: 768px) {
+    --main-content-padding: var(--magentaa11y-spacing-size-24)
+      var(--magentaa11y-spacing-size-16);
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,69 @@
-import React from 'react';
-import { Route, HashRouter as Router, Routes } from 'react-router-dom';
-import { Platforms } from 'shared/types/shared-types';
-import { ReactComponent as BookmarkIconOutlined } from './assets/svgs/bookmark-outlined.svg';
-import About from './components/about-us/about-us';
-import Criteria from './components/criteria/criteria';
-import Home from './components/home/home';
-import { NavItem } from './components/navigation/nav.types';
-import TopNav from './components/navigation/top-nav/top-nav';
+import React from "react";
+import {
+  Route,
+  HashRouter as Router,
+  Routes,
+  useLocation,
+} from "react-router-dom";
+import { Platforms } from "shared/types/shared-types";
+import { ReactComponent as BookmarkIconOutlined } from "./assets/svgs/bookmark-outlined.svg";
+import About from "./components/about-us/about-us";
+import Criteria from "./components/criteria/criteria";
+import Home from "./components/home/home";
+import { NavItem } from "./components/navigation/nav.types";
+import SideNav from "./components/navigation/side-nav/side-nav";
+import TopNav from "./components/navigation/top-nav/top-nav";
 
-import './App.scss';
+import "./App.scss";
+import Breadcrumbs from "components/navigation/breadcrumbs/breadcrumbs";
 
 const navItems: NavItem[] = [
-  { label: 'Web Criteria', href: '/web-criteria' },
-  { label: 'Native Criteria', href: '/native-criteria' },
-  { label: 'About us', href: '/about' },
+  { label: "Web Criteria", href: "/web-criteria" },
+  { label: "Native Criteria", href: "/native-criteria" },
+  { label: "About us", href: "/about" },
   {
-    label: 'My criteria',
-    href: '/my-criteria',
+    label: "My criteria",
+    href: "/my-criteria",
     icon: <BookmarkIconOutlined />,
   },
 ];
+
+const AppContent: React.FC = () => {
+  const location = useLocation();
+
+  // Determine if we should show the SideNav
+  const isCriteriaRoute =
+    location.pathname.startsWith("/web-criteria") ||
+    location.pathname.startsWith("/native-criteria");
+
+  // Determine the platform based on the route
+  const platform = location.pathname.startsWith("/web-criteria")
+    ? Platforms.WEB
+    : Platforms.NATIVE;
+
+  return (
+    <div className="MagentaA11y__content">
+      {/* Render SideNav only on the criteria pages */}
+      {isCriteriaRoute && <SideNav platform={platform} />}
+
+      <div className="MagentaA11y__main-content">
+        <Breadcrumbs />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
+          <Route
+            path="/web-criteria/*"
+            element={<Criteria platform={Platforms.WEB} />}
+          />
+          <Route
+            path="/native-criteria/*"
+            element={<Criteria platform={Platforms.NATIVE} />}
+          />
+        </Routes>
+      </div>
+    </div>
+  );
+};
 
 const App: React.FC = () => {
   return (
@@ -28,21 +72,7 @@ const App: React.FC = () => {
         <header className="MagentaA11y-header">
           <TopNav navItems={navItems} />
         </header>
-        <div className="MagentaA11y__content">
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/home" element={<Home />} />
-            <Route path="/about" element={<About />} />
-            <Route
-              path="/web-criteria/*"
-              element={<Criteria platform={Platforms.WEB} />}
-            />
-            <Route
-              path="/native-criteria/*"
-              element={<Criteria platform={Platforms.NATIVE} />}
-            />
-          </Routes>
-        </div>
+        <AppContent />
       </div>
     </Router>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   Route,
   HashRouter as Router,
@@ -40,6 +40,31 @@ const AppContent: React.FC = () => {
   const platform = location.pathname.startsWith("/web-criteria")
     ? Platforms.WEB
     : Platforms.NATIVE;
+
+  useEffect(() => {
+    const rawSegments = location.pathname
+      .replace("/MagentaA11yV2#", "")
+      .split("/")
+      .filter(Boolean);
+
+    let pageTitle = "MagentaA11y";
+
+    if (rawSegments.length > 0) {
+      let lastSegment = rawSegments[rawSegments.length - 1];
+
+      if (lastSegment.toLowerCase() === "overview" && rawSegments.length > 1) {
+        lastSegment = rawSegments[rawSegments.length - 2];
+      }
+
+      lastSegment = lastSegment
+        .replace(/-/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+
+      pageTitle = lastSegment;
+    }
+
+    document.title = pageTitle;
+  }, [location.pathname]);
 
   return (
     <div className="MagentaA11y__content">

--- a/src/components/content-display/content-display.scss
+++ b/src/components/content-display/content-display.scss
@@ -16,6 +16,7 @@
 
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: var(--nav-display-gap);
   max-width: 1280px;
   margin: auto;
@@ -23,6 +24,7 @@
   &__intro {
     display: flex;
     flex-direction: column;
+    width: 100%;
     gap: var(--intro-gap);
     text-align: center;
     padding-bottom: var(--intro-padding-bottom);
@@ -43,6 +45,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--nav-display-content-gap);
+    width: 100%;
   }
 
   &__content-actions {

--- a/src/components/criteria/criteria.scss
+++ b/src/components/criteria/criteria.scss
@@ -1,16 +1,10 @@
 .MagentaA11y {
-  --content-padding: 0 var(--magentaa11y-spacing-size-32);
   &__criteria-container {
     display: flex;
     width: -webkit-fill-available;
   }
 
   &__criteria-content {
-    padding: var(--content-padding);
     width: -webkit-fill-available;
-  }
-
-  @media (max-width: 768px) {
-    --content-padding: 0 var(--magentaa11y-spacing-size-16);
   }
 }

--- a/src/components/criteria/criteria.tsx
+++ b/src/components/criteria/criteria.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import contentData from '../../shared/content.json';
-import { Platforms } from '../../shared/types/shared-types';
-import ContentDisplay from '../content-display/content-display';
-import { SideNavItem } from '../navigation/nav.types';
-import SideNav from '../navigation/side-nav/side-nav';
+import React from "react";
+import contentData from "../../shared/content.json";
+import { Platforms } from "../../shared/types/shared-types";
+import ContentDisplay from "../content-display/content-display";
+import { SideNavItem } from "../navigation/nav.types";
 
-import './criteria.scss';
+import "./criteria.scss";
 
 interface CriteriaProps {
   platform: Platforms;
@@ -17,9 +16,6 @@ const Criteria: React.FC<CriteriaProps> = ({ platform }) => {
 
   return (
     <div className="MagentaA11y__criteria-container">
-      {/* SideNav remains persistent */}
-      <SideNav platform={platform} />
-
       {/* Main Content Section */}
       <div className="MagentaA11y__criteria-content">
         {/* Dynamically display ContentDisplay based on the current route */}

--- a/src/components/navigation/breadcrumbs/breadcrumbs.scss
+++ b/src/components/navigation/breadcrumbs/breadcrumbs.scss
@@ -1,0 +1,30 @@
+.MagentaA11y__breadcrumbs {
+  ol {
+    display: flex;
+    flex-direction: row;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li {
+      display: flex;
+      align-items: center;
+
+      &::before {
+        content: "/";
+        margin: 0 8px;
+        color: var(--breadcrumbs-text-default);
+      }
+
+      &:first-child::before {
+        display: none;
+      }
+
+      a {
+        text-decoration: none;
+        color: var(--breadcrumbs-text-default);
+        font: var(--magentaa11y-typeset-body-sm-normal);
+      }
+    }
+  }
+}

--- a/src/components/navigation/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/navigation/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import "./breadcrumbs.scss";
+
+const Breadcrumbs: React.FC = () => {
+  const location = useLocation();
+  const [breadcrumbItems, setBreadcrumbItems] = useState<
+    { path: string; label: string }[]
+  >([]);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkScreenSize = () => {
+      setIsMobile(window.matchMedia("(max-width: 768px)").matches);
+    };
+
+    checkScreenSize();
+    window.addEventListener("resize", checkScreenSize);
+
+    return () => window.removeEventListener("resize", checkScreenSize);
+  }, []);
+
+  useEffect(() => {
+    if (isMobile) return;
+
+    const rawSegments = location.pathname
+      .replace("/MagentaA11yV2#", "")
+      .split("/")
+      .filter(Boolean);
+
+    let builtPath = "";
+    const newBreadcrumbs: { path: string; label: string }[] = [];
+
+    rawSegments.forEach((segment, index) => {
+      builtPath += `/${segment}`;
+
+      let pathUrl = builtPath;
+      if (index < rawSegments.length - 1) {
+        pathUrl = `${builtPath}/overview`;
+      }
+
+      if (!newBreadcrumbs.some((crumb) => crumb.path === pathUrl)) {
+        newBreadcrumbs.push({
+          path: pathUrl,
+          label: segment
+            .replace(/-/g, " ")
+            .replace(/^./, (char) => char.toUpperCase()),
+        });
+      }
+    });
+
+    setBreadcrumbItems(newBreadcrumbs);
+  }, [location.pathname, isMobile]);
+
+  // Don't render breadcrumbs on mobile screens
+  if (isMobile) return null;
+
+  return (
+    <nav className="MagentaA11y__breadcrumbs" aria-label="Breadcrumb">
+      <ol>
+        <li>
+          <Link to="/">MagentaA11y</Link>
+        </li>
+
+        {breadcrumbItems.map(({ path, label }, index) => (
+          <li key={path}>
+            <Link
+              to={path}
+              aria-current={
+                index === breadcrumbItems.length - 1 ? "page" : undefined
+              }
+            >
+              {label}
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumbs;

--- a/src/components/navigation/top-nav/top-nav.tsx
+++ b/src/components/navigation/top-nav/top-nav.tsx
@@ -1,15 +1,15 @@
-import classNames from 'classnames';
-import React, { useState } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
-import { Icons } from 'shared/Icons';
-import { Platforms } from 'shared/types/shared-types';
-import contentData from '../../../shared/content.json';
-import { useViewport } from '../../../shared/contexts/viewport-context';
-import IconButton from '../../custom-components/buttons/icon-button/icon-button';
-import { TopNavProps } from '../nav.types';
-import { isPathActive } from 'utils/navigation-helpers';
+import classNames from "classnames";
+import React, { useState } from "react";
+import { NavLink, useLocation } from "react-router-dom";
+import { Icons } from "shared/Icons";
+import { Platforms } from "shared/types/shared-types";
+import contentData from "../../../shared/content.json";
+import { useViewport } from "../../../shared/contexts/viewport-context";
+import IconButton from "../../custom-components/buttons/icon-button/icon-button";
+import { TopNavProps } from "../nav.types";
+import { isPathActive } from "utils/navigation-helpers";
 
-import './top-nav.scss';
+import "./top-nav.scss";
 
 const getFirstOverviewLink = (platform: Platforms) => {
   const items = contentData[platform];
@@ -34,31 +34,33 @@ const TopNav: React.FC<TopNavProps> = ({ navItems }) => {
     <div className="MagentaA11y__navbar" data-theme="dark">
       {/* Brand Section */}
       <div className="MagentaA11y__brand">
-        <NavLink to="/home" className="MagentaA11y__brand--name">
+        <NavLink to="/" className="MagentaA11y__brand--name">
           A11y
         </NavLink>
       </div>
 
       {viewportContext.isMobile && (
         <IconButton
-          a11yLabel={'Menu Button'}
+          a11yLabel={"Menu Button"}
           icon={expanded ? Icons.closeOutlined : Icons.menu}
           ariaExpanded={expanded}
           ariaHasPopup={true}
           ariaControls="top-navigation"
-          onClick={handleMenuClick}></IconButton>
+          onClick={handleMenuClick}
+        ></IconButton>
       )}
 
       <nav
         className="MagentaA11y__navbar__nav"
         aria-label="Top navigation"
-        id="top-navigation">
+        id="top-navigation"
+      >
         <ul className="MagentaA11y__nav-items">
           {navItems.map((item, index) => {
             const href =
-              item.label === 'Web Criteria'
+              item.label === "Web Criteria"
                 ? getFirstOverviewLink(Platforms.WEB)
-                : item.label === 'Native Criteria'
+                : item.label === "Native Criteria"
                 ? getFirstOverviewLink(Platforms.NATIVE)
                 : item.href;
 
@@ -68,10 +70,11 @@ const TopNav: React.FC<TopNavProps> = ({ navItems }) => {
               <li key={index} className="MagentaA11y__nav-items--item">
                 <NavLink
                   to={href}
-                  className={classNames('MagentaA11y__nav-items--link', {
+                  className={classNames("MagentaA11y__nav-items--link", {
                     active: isActive,
                   })}
-                  aria-label={`Navigate to ${item.label}`}>
+                  aria-label={`Navigate to ${item.label}`}
+                >
                   {item.icon && (
                     <span className="MagentaA11y__nav-items--icon">
                       {item.icon}

--- a/src/styles/_color-tokens.scss
+++ b/src/styles/_color-tokens.scss
@@ -1,4 +1,4 @@
-@use './foundation-colors' as *;
+@use "./foundation-colors" as *;
 
 @mixin color-tokens($theme: light) {
   @if $theme == light {
@@ -189,6 +189,9 @@
     --button-tertiary-color: var(--magentaa11y-color-brand-grayscale-black);
     --button-tertiary-color-hover: var(--magentaa11y-color-brand-primary-400);
     --button-tertiary-color-pressed: var(--magentaa11y-color-brand-primary-600);
+
+    //breadcrumbs
+    --breadcrumbs-text-default: var(--magentaa11y-color-brand-grayscale-600);
   } @else if $theme == dark {
     // Dark Theme
     // Text Colors
@@ -370,5 +373,8 @@
     --button-tertiary-color: var(--magentaa11y-color-brand-grayscale-white);
     --button-tertiary-color-hover: var(--magentaa11y-color-brand-primary-400);
     --button-tertiary-color-pressed: var(--magentaa11y-color-brand-primary-100);
+
+    //breadcrumbs
+    --breadcrumbs-text-default: var(--magentaa11y-color-brand-grayscale-300);
   }
 }


### PR DESCRIPTION
# Merge Request: Update Layout, Navigation, and Breadcrumbs

## Changes

### Layout Updates
- Added `--main-content-padding` variable for spacing control.
- Wrapped content inside `.MagentaA11y__main-content` with updated styling and padding.
- Updated mobile-specific styles for spacing adjustments.

### Navigation Updates
- Added a `Breadcrumbs` component.
- Refactored `App.tsx`:
  - Moved routing logic into `AppContent` component.
  - Added logic to conditionally render `SideNav` based on the current route.
  - Updated document title based on the current page.
- Updated `TopNav`:
  - Changed home navigation link from `/home` to `/`.
  - Standardized icon button attributes.

### Styling Updates
- Updated `content-display.scss`:
  - Centered content items.
  - Applied full-width layout to sections.
- Updated `criteria.scss`:
  - Removed `--content-padding` variable.
- Added `breadcrumbs.scss` for breadcrumb styling.
- Updated `_color-tokens.scss`:
  - Added breadcrumb text color tokens for light and dark themes.

### New Components
- `Breadcrumbs.tsx`:
  - Generates breadcrumb links based on the current route.
  - Hides breadcrumbs on mobile screens.

### Code Removals and Refactoring
- Removed `SideNav` from `criteria.tsx`, as it is now conditionally rendered in `AppContent`.
- Consolidated styles and adjusted layout structure.
