### PR TITLE
feat: add 25 empty criteria to fill the page, add a forms group for web as well

### DIFF
--- a/public/content/documentation/web/component/alert-notification.md
+++ b/public/content/documentation/web/component/alert-notification.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test an alert notification
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/alert-notification](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/alert-notification)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/alert-notification](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/alert-notification)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/animation.md
+++ b/public/content/documentation/web/component/animation.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test an animation
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/animation](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/animation)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/animation](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/animation)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/carousel-slideshow.md
+++ b/public/content/documentation/web/component/carousel-slideshow.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a carousel/slideshow
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/carousel-slideshow](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/carousel-slideshow)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/carousel-slideshow](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/carousel-slideshow)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/complex-graphics.md
+++ b/public/content/documentation/web/component/complex-graphics.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a figure, map, chart, and other complex graphics
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/complex-graphics](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/complex-graphics)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/complex-graphics](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/complex-graphics)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/expander-accordion.md
+++ b/public/content/documentation/web/component/expander-accordion.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test an expander/accordion
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/expander-accordion](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/expander-accordion)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/expander-accordion](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/expander-accordion)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/footnote.md
+++ b/public/content/documentation/web/component/footnote.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a footnote
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/footnote](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/footnote)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/footnote](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/footnote)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/heading.md
+++ b/public/content/documentation/web/component/heading.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a heading: h1, h2, h3, h4, h5, h6
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/heading](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/heading)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/heading](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/heading)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/iframe.md
+++ b/public/content/documentation/web/component/iframe.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test an iframe
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/iframe](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/iframe)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/iframe](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/iframe)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/informative-image.md
+++ b/public/content/documentation/web/component/informative-image.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test an informative image
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/informative-image](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/informative-image)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/informative-image](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/informative-image)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/link.md
+++ b/public/content/documentation/web/component/link.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a link
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/link](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/link)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/link](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/link)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/list.md
+++ b/public/content/documentation/web/component/list.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a list
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/list](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/list)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/list](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/list)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/modal-dialog.md
+++ b/public/content/documentation/web/component/modal-dialog.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a modal dialog
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/modal-dialog](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/modal-dialog)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/modal-dialog](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/modal-dialog)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/pagination-nav.md
+++ b/public/content/documentation/web/component/pagination-nav.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a pagination nav
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/pagination-nav](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/pagination-nav)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/pagination-nav](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/pagination-nav)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/progress-indicator.md
+++ b/public/content/documentation/web/component/progress-indicator.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a progress indicator
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/progress-indicator](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/progress-indicator)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/progress-indicator](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/progress-indicator)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/scrolling-container.md
+++ b/public/content/documentation/web/component/scrolling-container.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a scrolling container
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/scrolling-container](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/scrolling-container)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/scrolling-container](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/scrolling-container)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/separator-horizontal-rule.md
+++ b/public/content/documentation/web/component/separator-horizontal-rule.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a separator/horizontal rule.
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/separator-horizontal-rule](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/separator-horizontal-rule)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/separator-horizontal-rule](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/separator-horizontal-rule)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/sticky-element.md
+++ b/public/content/documentation/web/component/sticky-element.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a sticky element
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/sticky-element](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/sticky-element)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/sticky-element](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/sticky-element)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/strikethrough-content.md
+++ b/public/content/documentation/web/component/strikethrough-content.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a strikethrough element
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/strikethrough-content](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/strikethrough-content)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/strikethrough-content](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/strikethrough-content)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/table.md
+++ b/public/content/documentation/web/component/table.md
@@ -1,6 +1,6 @@
 ## General Notes
 
-Tables must be used to structure tabular data. Avoid using tables for layout purposes.
+How to test a table
 
 ## Condensed
 
@@ -60,6 +60,7 @@ GIVEN THAT I am on a page with a table
 Full information: https://www.magentaa11y.com/#/web-criteria/component/table
 
 ## Code Examples
+Tables must be used to structure tabular data. Avoid using tables for layout purposes.
 
 ### Use Semantic HTML
 

--- a/public/content/documentation/web/component/tabs.md
+++ b/public/content/documentation/web/component/tabs.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test tabs
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tabs](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tabs)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tabs](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tabs)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/tidbit.md
+++ b/public/content/documentation/web/component/tidbit.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a tidbit
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tidbit](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tidbit)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tidbit](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tidbit)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/toast-snackbar.md
+++ b/public/content/documentation/web/component/toast-snackbar.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a toast snackbar
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/toast-snackbar](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/toast-snackbar)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/toast-snackbar](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/toast-snackbar)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/tooltip.md
+++ b/public/content/documentation/web/component/tooltip.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a tooltip
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tooltip](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tooltip)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tooltip](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/tooltip)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/component/video-audio-player.md
+++ b/public/content/documentation/web/component/video-audio-player.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a video/audio player
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/video-audio-player](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/video-audio-player)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/video-audio-player](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/component/video-audio-player)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/form/checkbox.md
+++ b/public/content/documentation/web/form/checkbox.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a checkbox
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/form/checkbox](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/form/checkbox)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/form/checkbox](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/form/checkbox)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/public/content/documentation/web/form/radio-button.md
+++ b/public/content/documentation/web/form/radio-button.md
@@ -1,0 +1,80 @@
+## General Notes
+
+How to test a radio button
+
+## Condensed
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+1. Test keyboard only, then screen reader + keyboard actions
+
+   - Skip-links: Focus moves directly to the header or navigation
+
+   - Tab: Nothing, headings are not focusable unless they are actionable
+
+   - Arrow-keys: Headings are browsed
+
+2. Test mobile screenreader gestures
+
+   - Swipe: Focus moves directly to the header or navigation
+
+   - Doubletap: This typically activates most elements
+
+3. Listen to screenreader output on all devices
+
+   - It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - Group: It typically contains the name and primary navigation of the website
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/form/radio-button](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/form/radio-button)
+
+## Gherkin
+
+### #a11y - Web Accessibility Acceptance Criteria
+
+How to test a header
+
+GIVEN THAT I am on a page with a header landmark
+
+1. Keyboard for mobile & desktop
+
+   - WHEN I use the tab key to enter the web browser window I SEE focus is strongly visually indicated on interactive components
+
+2. Desktop screenreader
+
+   - WHEN I use a desktop screenreader (NVDA, JAWS, VoiceOver) AND
+
+   - I use the tab key to enter the web browser window
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+3. Mobile screenreader
+
+   - WHEN I use a mobile screenreader (Talkback, VoiceOver) AND
+
+   - I swipe to focusable elements in the header
+
+   - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
+
+   - I HEAR It typically contains the name and primary navigation of the website
+
+
+Full information: [https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/form/radio-button](https://www.magentaa11y.com/MagentaA11yV2#/web-criteria/form/radio-button)
+
+## Developer Notes
+
+### Name
+
+- Typically doesn’t have a name or description since there must be only one instance per page.
+
+## Videos
+
+- Videos go here
+<video controls>
+  <source src="media/video/native/button/buttonIosVoiceover.webm" type="video/webm">
+  Your browser does not support the video tag.
+</video>

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -7,7 +7,7 @@ const cardContent = [
   {
     "title": "Web accessibility checker",
     "description": "Choose components to define your accessibility success criteria",
-    "link": "/web-criteria/page-level/overview"
+    "link": "/web-criteria/component/overview"
   },
   {
     "title": "Native accessibility checker",


### PR DESCRIPTION
I've been asked to make the criteria page look "fuller" so I have adde a bunch of components for web criteria that do NOT have the correct docs/gherkin etc. I just added the templates/saved.

- [ ] run the site and make sure the web criteria look ok/ that the descriptions look good
- [ ] cross compare the new criteria and see if I added all the non-web web criteria added to components. I recommend using https://www.magentaa11y.com/web/ and check them off as you go!
- FYI: I decided forms was a different enough section and I'm not going to add all of those yet.