### PR TITLE
Styles: Fix CSS, second round

### DIFF
--- a/src/components/content-display/markdown-content/markdown-content.scss
+++ b/src/components/content-display/markdown-content/markdown-content.scss
@@ -108,19 +108,18 @@
   input[type="tel"], 
   input[type="number"], 
   input[type="password"], 
-  input[type="button"], 
-  input[type="submit"] {
+  input[type="button"] {
     border: 2px solid black;
     border-radius: 2px;
     box-shadow: 0 0 0 3px #fff;
     display: block;
     font-size: 1.125rem;
     padding: .75rem .5rem;
-    -webkit-appearance: none;
     width: auto;
 
       &:focus-visible {
         outline: 3px solid #222;
+        transition: .25s ease;
       }
   }
 

--- a/src/components/content-display/markdown-content/markdown-content.scss
+++ b/src/components/content-display/markdown-content/markdown-content.scss
@@ -20,6 +20,26 @@
     font: var(--content-details-header-font);
   }
 
+  h2 {
+    font-size: 2rem;
+  }
+
+  h3 {
+    font-size: 1.375rem;
+
+    code {
+      font-size: 1rem;
+    }
+  }
+
+  & > h2 { 
+    margin: 3rem 0 2rem;
+  }
+
+  & > h2:first-child {
+    margin: 1rem 0;
+  }
+
   ol {
     list-style: none;
     padding: 0;

--- a/src/components/content-display/markdown-content/markdown-content.scss
+++ b/src/components/content-display/markdown-content/markdown-content.scss
@@ -3,6 +3,7 @@
 .MagentaA11y__content-details {
   --content-details-padding: var(--magentaa11y-spacing-size-24);
   --content-details-header-font: var(--magentaa11y-typeset-body-xxl-strong);
+  --content-details-label-font:  var(--magentaa11y-typeset-body-lg-strong);
   --external-links-background-img: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%23e20074' d='M9 42q-1.2 0-2.1-.9Q6 40.2 6 39V9q0-1.2.9-2.1Q7.8 6 9 6h13.95v3H9v30h30V25.05h3V39q0 1.2-.9 2.1-.9.9-2.1.9Zm10.1-10.95L17 28.9 36.9 9H25.95V6H42v16.05h-3v-10.9Z'/%3E%3C/svg%3E");
 
   border: solid var(--color-on-surface-variant)
@@ -33,6 +34,7 @@
   }
 
   & > h2 { 
+    line-height: 1.125;
     margin: 3rem 0 2rem;
   }
 
@@ -95,5 +97,45 @@
     position: absolute;
     bottom: 0;
     fill: var(--magentaa11y-color-fill-divider-brand);
+  }
+
+  textarea, 
+  input[type="text"], 
+  input[type="search"], 
+  input[type="file"], 
+  input[type="email"], 
+  input[type="date"], 
+  input[type="tel"], 
+  input[type="number"], 
+  input[type="password"], 
+  input[type="button"], 
+  input[type="submit"] {
+    border: 2px solid black;
+    border-radius: 2px;
+    box-shadow: 0 0 0 3px #fff;
+    display: block;
+    font-size: 1.125rem;
+    padding: .75rem .5rem;
+    -webkit-appearance: none;
+    width: auto;
+
+      &:focus-visible {
+        outline: 3px solid #222;
+      }
+  }
+
+  label {
+    display: block;
+    font: var(--content-details-label-font);
+    margin: 0 0 .5rem;
+    position: relative;
+  }
+
+  .hint {
+    margin: 0.675rem 0 1rem;
+    padding: 0;
+    color: #676767;
+    display: block;
+    border-radius: 2px;
   }
 }

--- a/src/components/content-display/markdown-content/markdown-content.scss
+++ b/src/components/content-display/markdown-content/markdown-content.scss
@@ -104,42 +104,4 @@
     fill: var(--magentaa11y-color-fill-divider-brand);
   }
 
-  textarea, 
-  input[type="text"], 
-  input[type="search"], 
-  input[type="file"], 
-  input[type="email"], 
-  input[type="date"], 
-  input[type="tel"], 
-  input[type="number"], 
-  input[type="password"], 
-  input[type="button"] {
-    border: 2px solid black;
-    border-radius: 2px;
-    box-shadow: 0 0 0 3px #fff;
-    display: block;
-    font-size: 1.125rem;
-    padding: .75rem .5rem;
-    width: auto;
-
-      &:focus-visible {
-        outline: 3px solid #222;
-        transition: .25s ease;
-      }
-  }
-
-  label {
-    display: block;
-    font: var(--content-details-label-font);
-    margin: 0 0 .5rem;
-    position: relative;
-  }
-
-  .hint {
-    margin: 0.675rem 0 1rem;
-    padding: 0;
-    color: #676767;
-    display: block;
-    border-radius: 2px;
-  }
 }

--- a/src/components/content-display/markdown-content/markdown-content.scss
+++ b/src/components/content-display/markdown-content/markdown-content.scss
@@ -25,14 +25,6 @@
     font-size: 2rem;
   }
 
-  h3 {
-    font-size: 1.375rem;
-
-    code {
-      font-size: 1rem;
-    }
-  }
-
   & > h2 { 
     line-height: 1.125;
     margin: 3rem 0 2rem;
@@ -40,6 +32,19 @@
 
   & > h2:first-child {
     margin: 1rem 0;
+  }
+
+  h3 {
+    font-size: 1.375rem;
+    margin: 2rem 0 0.75rem;
+
+    code {
+      font-size: 1rem;
+    }
+  }
+
+  h4 {
+    font-size: 1.125rem;
   }
 
   ol {

--- a/src/components/custom-components/cards/cards.scss
+++ b/src/components/custom-components/cards/cards.scss
@@ -39,7 +39,7 @@
     }
 
     &__description {
-      font: normal 14px / 18px var(--magentaa11y-font-family-body);
+      font: normal 14px / 24px var(--magentaa11y-font-family-body);
       color: var(--color-on-surface);
     }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -52,7 +52,6 @@ h1 {
 
 h2 {
   line-height: var(--magentaa11y-line-height-43);
-  margin: 2rem 0 1rem;
 }
 
 h3,

--- a/src/index.scss
+++ b/src/index.scss
@@ -52,6 +52,7 @@ h1 {
 
 h2 {
   line-height: var(--magentaa11y-line-height-43);
+  margin: 2rem 0 1rem;
 }
 
 h3,

--- a/src/index.scss
+++ b/src/index.scss
@@ -87,9 +87,8 @@ button {
 }
 
 pre {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
-  padding: 1em;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+  padding: 2em;
   overflow-x: auto;
   border-radius: 4px;
   width: -webkit-fill-available;

--- a/src/index.scss
+++ b/src/index.scss
@@ -68,7 +68,7 @@ p,
 li,
 ul,
 ol {
-  line-height: var(--magentaa11y-line-height-20);
+  line-height: var(--magentaa11y-line-height-24);
 }
 
 ul,

--- a/src/styles/_code-blocks.scss
+++ b/src/styles/_code-blocks.scss
@@ -1,9 +1,7 @@
 /* Base styles for code blocks */
 pre {
-  font-family: monospace;
-  font-size: 0.875rem;
+  font-size: 1rem;
   line-height: 1.6;
-  padding: 1rem;
   margin: 1rem 0;
   border-radius: 6px;
   background-color: var(--color-code-block); /* Adapts to theme */

--- a/src/styles/_code-blocks.scss
+++ b/src/styles/_code-blocks.scss
@@ -1,7 +1,7 @@
 /* Base styles for code blocks */
 pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: 14px;
+  font-family: monospace;
+  font-size: 0.875rem;
   line-height: 1.6;
   padding: 1rem;
   margin: 1rem 0;
@@ -12,8 +12,17 @@ pre {
 }
 
 code {
-  font-family: "Courier New", Courier, monospace;
+  font-family: monospace;
+  color: var(--color-text-secondary);
 
+}
+
+:not(pre) > code {
+  background: var(--color-background-secondary);
+  padding: 0.15em 0.33em 0.1em;
+  border: solid var(--color-background-tertiary);
+  border-width: 1px;
+  border-radius: 8px;
 }
 
 /* Syntax Highlighting with hljs classes */

--- a/src/styles/_code-blocks.scss
+++ b/src/styles/_code-blocks.scss
@@ -13,7 +13,7 @@ pre {
 
 code {
   font-family: "Courier New", Courier, monospace;
-  font-style: italic;
+
 }
 
 /* Syntax Highlighting with hljs classes */
@@ -37,7 +37,6 @@ code {
 /* Tag attributes (e.g., id, class) */
 .hljs-attr {
   color: var(--color-info); /* Tertiary color for attributes */
-  font-style: italic;
 }
 
 /* Attribute values (e.g., "example-header") */
@@ -49,7 +48,7 @@ code {
 /* Comments */
 .hljs-comment {
   color: var(--color-text-secondary); /* Muted color for comments */
-  font-style: italic;
+
 }
 
 /* Punctuation (e.g., <> and =) */

--- a/src/styles/_md-styles.scss
+++ b/src/styles/_md-styles.scss
@@ -109,6 +109,24 @@ example, /* stylelint-disable-line selector-type-no-unknown */
     }
   }
   /* stylelint-enable no-descending-specificity */
+
+  .spa {
+    .slide-list {
+      margin: 0;
+      padding: 0;
+    }
+
+    .slide {
+      list-style: none;
+      background: var(--color-on-primary);
+      padding: 1rem;
+      margin-top: 1rem;
+
+      &:not(.visible) {
+        display: none;
+      }
+    }
+  }
   
   .stepper {
     display: inline-grid;
@@ -130,38 +148,46 @@ example, /* stylelint-disable-line selector-type-no-unknown */
     background: var(--color-background-secondary);
   }
 
+  textarea, 
+  input[type="text"], 
+  input[type="email"], 
+  input[type="date"], 
+  input[type="tel"], 
+  input[type="number"], 
+  input[type="password"], 
+  input[type="button"] {
+    border: 2px solid var(--color-on-background);
+    border-radius: 2px;
+    display: block;
+    font-size: 1.125rem;
+    padding: .75rem .5rem;
+    width: auto;
+  }
+
+  input[type="text"]:disabled,
+  input[type="text"][aria-disabled="true"] {
+    background: var(--magentaa11y-color-brand-grayscale-400);
+  }
+
   // search input example
   form[role="search"] {
+    box-shadow: 0 0 0 3px var(--color-on-primary);
     display: flex;
-    padding: 1rem;
     transition: 0.7s;
     border-radius: 0.125rem;
-    box-shadow: 0 1px 2px 1px rgba(var(--color-on-tertiary), 0.1);
-
-    /* stylelint-disable no-descending-specificity */
-    &:focus-within,
-    &:hover {
-      background: var(--color-on-primary);
-      box-shadow: 0 1px 4px 1px rgba(var(--color-on-tertiary), 0.3);
-    }
-    /* stylelint-enable no-descending-specificity */
 
     input[type="search"] {
+      background-color: var(--color-on-primary);
+      border: 2px solid var(--color-on-background);
+      border-radius: 0;
       border-right: none;
-      position: relative;
       display: block;
-      width: 100%;
-      text-indent: 0.5rem;
       line-height: 0;
       margin: 0;
       padding: 0;
-      border-radius: 0;
-      box-shadow: none;
-      background-color: var(--color-on-primary);
-
-      &:focus {
-        z-index: 99;
-      }
+      position: relative;
+      text-indent: 0.5rem;
+      width: 100%;
 
       &::-webkit-calendar-picker-indicator {
         display: none !important;
@@ -169,21 +195,20 @@ example, /* stylelint-disable-line selector-type-no-unknown */
     }
 
     button {
+      background: var(--color-on-primary);
+      border: 2px solid var(--color-on-tertiary);;
+      border-left: none;
       display: block;
-      position: relative;
+      height: 2.375rem;
       line-height: 0;
       margin: 0;
       padding: 0;
-      height: 2.375rem;
+      position: relative;
       width: 2.25rem;
-      background: var(--color-on-primary);
-      border: 2px solid black;
-      border-left: none;
     }
   }
 
   .tidbit {
-    /* stylelint-disable no-descending-specificity */
     display: grid;
     grid-template-columns: 40px 1fr;
     align-content: start;
@@ -218,7 +243,6 @@ example, /* stylelint-disable-line selector-type-no-unknown */
         fill: var(--color-success);
       }
     }
-    /* stylelint-enable no-descending-specificity */
 
     h2 {
       margin: 0;
@@ -231,22 +255,19 @@ example, /* stylelint-disable-line selector-type-no-unknown */
     }
   }
 
-  .spa {
-    .slide-list {
-      margin: 0;
-      padding: 0;
-    }
+  label {
+    display: block;
+    font: var(--content-details-label-font);
+    margin: 0 0 .5rem;
+    position: relative;
+  }
 
-    .slide {
-      list-style: none;
-      background: var(--color-on-primary);
-      padding: 1rem;
-      margin-top: 1rem;
-
-      &:not(.visible) {
-        display: none;
-      }
-    }
+  .hint {
+    margin: 0.675rem 0 1rem;
+    padding: 0;
+    color: var(--color-text-disabled);
+    display: block;
+    border-radius: 2px;
   }
 }
 
@@ -259,7 +280,7 @@ example, /* stylelint-disable-line selector-type-no-unknown */
   background: #fff;
   padding: 1rem 0 1rem 1rem;
   border-radius: 2px;
-  box-shadow: 0 0 3px 1px rgba(#000, .1);
+  box-shadow: 0 0 3px 1px var(--color-on-tertiary);
 
   * {
     margin: 0 !important;
@@ -269,6 +290,7 @@ example, /* stylelint-disable-line selector-type-no-unknown */
   p {
     padding: 0 0 0 1rem;
   }
+  
 }
 
 .sticky-wrapper {
@@ -301,7 +323,7 @@ example, /* stylelint-disable-line selector-type-no-unknown */
 .stars {
   display: inline-block;
   padding: 1rem 1.25rem;
-  background: #fff;
+  background: var(--color-on-primary);
   font-size: 2rem;
   letter-spacing: .25rem;
   margin-bottom: 3rem;
@@ -346,43 +368,13 @@ example, /* stylelint-disable-line selector-type-no-unknown */
 .star-rating {
   display: flex;
   align-items: center;
-  
+
   // flex-direction: row-reverse; /* Keep row-reverse for visual order */
   justify-content: space-around;
 }
 
-<<<<<<< HEAD
 /* stylelint-disable no-descending-specificity */
 input.star + label {
-=======
-// .star-rating label {
-//   position: relative;
-//   padding: 1rem 0;
-//   height: 4rem;
-//   line-height: 1;
-//   width: fit-content;
-//   cursor: pointer;
-//   transition: opacity .2s;
-//   display: flex;
-//   align-items: center;
-//   justify-content: center;
-// }
-
-
-.star-rating input.star {
-  position: absolute; /* Keep radio buttons off-screen */
-  opacity: 0;
-}
-
-input.star:focus + label,
-input.star:focus-visible + label {
-  outline: .5rem auto Highlight;
-  outline: -webkit-focus-ring-color auto 1px;
-  outline-offset: 4px;
-}
-
-.star-rating input.star + label {
->>>>>>> f2f2576 (rework star rating styles)
   padding: 1rem 0;
   height: 4rem;
   width: fit-content;
@@ -403,7 +395,6 @@ input.star:focus-visible + label {
   }
 }
 
-<<<<<<< HEAD
 input[type="radio"]:checked ~ label::before {
   background: url("../assets/svgs/star-filled.svg") no-repeat 0 0;
 }
@@ -413,20 +404,9 @@ input[type="radio"]:checked ~ label::before {
   height: 250px;
   overflow: auto;
 }
-
-.hint {
-  margin: 0 0 1rem;
-  padding: 0;
-  color: var(--color-on-surface);
-  display: block;
-  border-radius: 2px;
-}
-=======
 .star-rating input.star:checked ~ label::before {
-    background: url("../assets/svgs/star-filled.svg") no-repeat center center;
-  }
->>>>>>> f2f2576 (rework star rating styles)
-
+  background: url("../assets/svgs/star-filled.svg") no-repeat center center;
+}
 
 
 

--- a/src/styles/_md-styles.scss
+++ b/src/styles/_md-styles.scss
@@ -17,6 +17,7 @@
   color: black;
 }
 
+/* stylelint-disable no-descending-specificity */
 example, /* stylelint-disable-line selector-type-no-unknown */
 .example {
   padding: 2rem;
@@ -46,7 +47,6 @@ example, /* stylelint-disable-line selector-type-no-unknown */
     background: var(--color-text-on-primary);
   }
 
-  /* stylelint-disable no-descending-specificity */
   .switch {
     max-width: 450px;
     margin: 0;
@@ -108,7 +108,6 @@ example, /* stylelint-disable-line selector-type-no-unknown */
       }
     }
   }
-  /* stylelint-enable no-descending-specificity */
 
   .spa {
     .slide-list {
@@ -291,7 +290,6 @@ example, /* stylelint-disable-line selector-type-no-unknown */
   p {
     padding: 0 0 0 1rem;
   }
-  
 }
 
 .sticky-wrapper {
@@ -328,7 +326,7 @@ example, /* stylelint-disable-line selector-type-no-unknown */
   font-size: 2rem;
   letter-spacing: .25rem;
   margin-bottom: 3rem;
-  box-shadow: 0 0 5px 1px rgba(#000, .1);
+  box-shadow: 0 0 5px 1px rgba(var(--color-on-tertiary), .1);
   position: relative;
 
   .scale {
@@ -365,17 +363,25 @@ example, /* stylelint-disable-line selector-type-no-unknown */
   }
 }
 
-
 .star-rating {
   display: flex;
   align-items: center;
-
-  // flex-direction: row-reverse; /* Keep row-reverse for visual order */
   justify-content: space-around;
 }
 
-/* stylelint-disable no-descending-specificity */
-input.star + label {
+.star-rating input.star {
+  position: absolute; /* Keep radio buttons off-screen */
+  opacity: 0;
+}
+
+input.star:focus + label,
+input.star:focus-visible + label {
+  outline: .5rem auto Highlight;
+  outline: -webkit-focus-ring-color auto 1px;
+  outline-offset: 4px;
+}
+
+.star-rating input.star + label {
   padding: 1rem 0;
   height: 4rem;
   width: fit-content;
@@ -396,20 +402,14 @@ input.star + label {
   }
 }
 
-input[type="radio"]:checked ~ label::before {
-  background: url("../assets/svgs/star-filled.svg") no-repeat 0 0;
-}
-/* stylelint-enable no-descending-specificity */
-
 .scrolling-container {
   height: 250px;
   overflow: auto;
 }
+
 .star-rating input.star:checked ~ label::before {
   background: url("../assets/svgs/star-filled.svg") no-repeat center center;
 }
-
-
 
 /* Reverse the visual order of the labels */
 .star-rating input.star#star-1 + label { order: 5; }
@@ -417,3 +417,5 @@ input[type="radio"]:checked ~ label::before {
 .star-rating input.star#star-3 + label { order: 3; }
 .star-rating input.star#star-4 + label { order: 2; }
 .star-rating input.star#star-5 + label { order: 1; }
+
+/* stylelint-enable no-descending-specificity */

--- a/src/styles/_md-styles.scss
+++ b/src/styles/_md-styles.scss
@@ -346,40 +346,37 @@ example, /* stylelint-disable-line selector-type-no-unknown */
 .star-rating {
   display: flex;
   align-items: center;
+  flex-direction: row-reverse;
   justify-content: space-around;
 }
 
- /* stylelint-disable no-descending-specificity */
+/* stylelint-disable no-descending-specificity */
 input.star + label {
-    padding: 1rem 0;
+  padding: 1rem 0;
+  height: 4rem;
+  line-height: 1;
+  width: fit-content;
+  cursor: pointer;
+
+  &:hover {
+    opacity: .5;
+  }
+
+  &::before {
+    content: "";
+    display: block;
+    width: 4rem;
     height: 4rem;
-    line-height: 1;
-    width: fit-content;
-    cursor: pointer;
-
-    &:hover {
-      opacity: .5;
-    }
-
-    &::before {
-      content: "";
-      display: block;
-      width: 4rem;
-      height: 4rem;
-      border: none;
-      background: url("../assets/svgs/star-outlined.svg") no-repeat 0 0;
-      transition: background-color .2s;
-    }
+    border: none;
+    background: url("../assets/svgs/star-outlined.svg") no-repeat 0 0;
+    transition: background-color .2s;
   }
+}
 
-  input[type="radio"]:checked ~ label::before {
-    background: url("../assets/svgs/star-filled.svg") no-repeat 0 0;
-  }
-
-  input.star:focus {
-    outline: red;
-  }
-  /* stylelint-enable no-descending-specificity */
+input[type="radio"]:checked ~ label::before {
+  background: url("../assets/svgs/star-filled.svg") no-repeat 0 0;
+}
+/* stylelint-enable no-descending-specificity */
 
 .scrolling-container {
   height: 250px;
@@ -393,3 +390,11 @@ input.star + label {
   display: block;
   border-radius: 2px;
 }
+
+input.star:focus + label,
+input.star:focus-visible + label {
+  outline: .5rem auto Highlight;
+  outline: -webkit-focus-ring-color auto 1px;
+  outline-offset: 4px;
+}
+

--- a/src/styles/_md-styles.scss
+++ b/src/styles/_md-styles.scss
@@ -133,12 +133,10 @@ example, /* stylelint-disable-line selector-type-no-unknown */
   // search input example
   form[role="search"] {
     display: flex;
-    max-width: auto;
     padding: 1rem;
     transition: 0.7s;
     border-radius: 0.125rem;
     box-shadow: 0 1px 2px 1px rgba(var(--color-on-tertiary), 0.1);
-    background: var(--color-background-secondary);
 
     /* stylelint-disable no-descending-specificity */
     &:focus-within,
@@ -179,7 +177,7 @@ example, /* stylelint-disable-line selector-type-no-unknown */
       height: 2.375rem;
       width: 2.25rem;
       background: var(--color-on-primary);
-      border: 3px solid var(--color-input-border);
+      border: 2px solid black;
       border-left: none;
     }
   }

--- a/src/styles/_md-styles.scss
+++ b/src/styles/_md-styles.scss
@@ -346,15 +346,45 @@ example, /* stylelint-disable-line selector-type-no-unknown */
 .star-rating {
   display: flex;
   align-items: center;
-  flex-direction: row-reverse;
+  
+  // flex-direction: row-reverse; /* Keep row-reverse for visual order */
   justify-content: space-around;
 }
 
+<<<<<<< HEAD
 /* stylelint-disable no-descending-specificity */
 input.star + label {
+=======
+// .star-rating label {
+//   position: relative;
+//   padding: 1rem 0;
+//   height: 4rem;
+//   line-height: 1;
+//   width: fit-content;
+//   cursor: pointer;
+//   transition: opacity .2s;
+//   display: flex;
+//   align-items: center;
+//   justify-content: center;
+// }
+
+
+.star-rating input.star {
+  position: absolute; /* Keep radio buttons off-screen */
+  opacity: 0;
+}
+
+input.star:focus + label,
+input.star:focus-visible + label {
+  outline: .5rem auto Highlight;
+  outline: -webkit-focus-ring-color auto 1px;
+  outline-offset: 4px;
+}
+
+.star-rating input.star + label {
+>>>>>>> f2f2576 (rework star rating styles)
   padding: 1rem 0;
   height: 4rem;
-  line-height: 1;
   width: fit-content;
   cursor: pointer;
 
@@ -368,11 +398,12 @@ input.star + label {
     width: 4rem;
     height: 4rem;
     border: none;
-    background: url("../assets/svgs/star-outlined.svg") no-repeat 0 0;
+    background: url("../assets/svgs/star-outlined.svg") no-repeat center center;
     transition: background-color .2s;
   }
 }
 
+<<<<<<< HEAD
 input[type="radio"]:checked ~ label::before {
   background: url("../assets/svgs/star-filled.svg") no-repeat 0 0;
 }
@@ -390,11 +421,18 @@ input[type="radio"]:checked ~ label::before {
   display: block;
   border-radius: 2px;
 }
+=======
+.star-rating input.star:checked ~ label::before {
+    background: url("../assets/svgs/star-filled.svg") no-repeat center center;
+  }
+>>>>>>> f2f2576 (rework star rating styles)
 
-input.star:focus + label,
-input.star:focus-visible + label {
-  outline: .5rem auto Highlight;
-  outline: -webkit-focus-ring-color auto 1px;
-  outline-offset: 4px;
-}
 
+
+
+/* Reverse the visual order of the labels */
+.star-rating input.star#star-1 + label { order: 5; }
+.star-rating input.star#star-2 + label { order: 4; }
+.star-rating input.star#star-3 + label { order: 3; }
+.star-rating input.star#star-4 + label { order: 2; }
+.star-rating input.star#star-5 + label { order: 1; }

--- a/src/styles/_md-styles.scss
+++ b/src/styles/_md-styles.scss
@@ -148,6 +148,7 @@ example, /* stylelint-disable-line selector-type-no-unknown */
     background: var(--color-background-secondary);
   }
 
+  // text input styles within examples
   textarea, 
   input[type="text"], 
   input[type="email"], 
@@ -166,7 +167,7 @@ example, /* stylelint-disable-line selector-type-no-unknown */
 
   input[type="text"]:disabled,
   input[type="text"][aria-disabled="true"] {
-    background: var(--magentaa11y-color-brand-grayscale-400);
+    background: var(--magentaa11y-color-brand-grayscale-300);
   }
 
   // search input example


### PR DESCRIPTION
MD content:
- added margin to H2s
- edited styling of `<code>` blocks and inline `code`
- edited line-height for readability
- increased font-size of headings in mardown-content.scss
- added styling of text/number/password input and label elements (including hints) within examples
- adjusted the example in the search component to match up to added input styles above